### PR TITLE
Context APIでグローバルなstateを管理するの提出物です

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="utf-8" />

--- a/src/components/EditForm.jsx
+++ b/src/components/EditForm.jsx
@@ -1,4 +1,6 @@
+import useContents from "../hooks/useContents";
 import DeleteButton from "./DeleteButton";
+import { useLogin } from "../hooks/useLogin";
 
 const EditForm = (props) => {
   const handleChange = (event) => {
@@ -9,20 +11,23 @@ const EditForm = (props) => {
     event.preventDefault();
     props.handleClickUpdateButton();
   };
+  const { isLogin } = useLogin();
 
   return (
     <div>
       <form onSubmit={(event) => handleSubmit(event)}>
         <textarea type="text" value={props.text} onChange={handleChange} />
-        <div className="buttons">
-          <input type="submit" value="編集" className="submit" />
-          {
-            <DeleteButton
-              handleClickDeleteButton={props.handleClickDeleteButton}
-              editingId={props.editingId}
-            />
-          }
-        </div>
+        {isLogin && (
+          <div className="buttons">
+            <input type="submit" value="編集" className="submit" />
+            {
+              <DeleteButton
+                handleClickDeleteButton={props.handleClickDeleteButton}
+                editingId={props.editingId}
+              />
+            }
+          </div>
+        )}
       </form>
     </div>
   );

--- a/src/components/LoginButton.jsx
+++ b/src/components/LoginButton.jsx
@@ -1,0 +1,9 @@
+const LoginButton = (props) => {
+  return (
+    <button className="LoginButton" onClick={props.handleClickLoginButton}>
+      {props.isLogin ? "ログアウト" : "ログイン"}
+    </button>
+  );
+};
+
+export default LoginButton;

--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -62,7 +62,7 @@ const Todo = () => {
               </div>
             );
           })}
-          <NewButton handleClickNewButton={handleClickNewButton} />
+          {isLogin && <NewButton handleClickNewButton={handleClickNewButton} />}
         </div>
 
         <div className="contentArea">

--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -20,8 +20,9 @@ const Todo = () => {
     const newId = calcNewId(contents);
     setShowEditForm(true);
     setEditingId(newId);
-    setText("新規メモ");
-    addContent(newId, text);
+    const initialTitle = "新規メモ";
+    setText(initialTitle);
+    addContent(newId, initialTitle);
   };
 
   const handleClickUpdateButton = () => {

--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -3,12 +3,19 @@ import NewButton, { calcNewId } from "./NewButton";
 import ShowButton from "./ShowButton";
 import EditForm from "./EditForm";
 import useContents from "../hooks/useContents";
+import LoginButton from "./LoginButton";
+import { useLogin } from "../hooks/useLogin";
 
 const Todo = () => {
   const [showEditForm, setShowEditForm] = useState(false);
   const [editingId, setEditingId] = useState("");
   const [text, setText] = useState("");
   const { contents, addContent, updateContent, deleteContent } = useContents();
+  const { isLogin, changeLoginStatus } = useLogin();
+
+  const handleClickLoginButton = () => {
+    changeLoginStatus();
+  };
 
   const handleClickShowButton = (content) => {
     setShowEditForm(true);
@@ -38,6 +45,10 @@ const Todo = () => {
   return (
     <div className="outerLine">
       <h3>{showEditForm ? "編集" : "一覧"}</h3>
+      <LoginButton
+        isLogin={isLogin}
+        handleClickLoginButton={handleClickLoginButton}
+      ></LoginButton>
       <div className="innerLine">
         <div className="titleArea">
           {contents.map((content) => {

--- a/src/hooks/useLogin.js
+++ b/src/hooks/useLogin.js
@@ -1,0 +1,18 @@
+import { createContext, useContext, useState } from "react";
+
+const LoginContext = createContext();
+
+export const LoginProvider = ({ children }) => {
+  const [isLogin, setIsLogin] = useState(false);
+  const changeLoginStatus = () => setIsLogin(!isLogin);
+
+  return (
+    <LoginContext.Provider value={{ isLogin, changeLoginStatus }}>
+      {children}
+    </LoginContext.Provider>
+  );
+};
+
+export const useLogin = () => {
+  return useContext(LoginContext);
+};

--- a/src/index.css
+++ b/src/index.css
@@ -68,3 +68,8 @@ textarea {
   border-radius: 5px;
   cursor: pointer;
 }
+
+.LoginButton {
+  border-radius: 5px;
+  cursor: pointer;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import Todo from "./components/Todo";
+import { LoginProvider } from "./hooks/useLogin";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <Todo />
+    <LoginProvider>
+      <Todo />
+    </LoginProvider>
   </React.StrictMode>
 );

--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,5 @@ root.render(
     <LoginProvider>
       <Todo />
     </LoginProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
[Context APIでグローバルなstateを管理する](https://bootcamp.fjord.jp/practices/253)の提出物です。

## やったこと
* カスタムフック`useLogin`を追加しました。
* `LoginButton`を追加しました。
* `isLogin`がtrueの場合ログイン状態とし、ログイン状態の時のみ新規作成、編集、削除ボタンが表示されるようにしました。

## やらなかったこと
* DevToolなどでlocalStorageを直接編集することを禁止するような機能は実装していません。

## 気になっている部分
Prettier実行時にインストールを促されたためインストールしたところ、<!DOCTYPE html>`を`<!doctype html>`に書き換えるようになりました。
今まで`<!DOCTYPE html>`で通っていたのですが、どちらの挙動が正しいのでしょうか？